### PR TITLE
Backwards compatibility

### DIFF
--- a/admin-notices-ms.php
+++ b/admin-notices-ms.php
@@ -82,8 +82,8 @@ final class Admin_Notices_MS {
 		$this->plugin_file = isset($plugin_file)? $plugin_file : __FILE__;
 
 		// Admin notices both in admin and network admin
-		add_action('admin_notices', [&$this, 'adminNoticesMS']);
-		add_action('network_admin_notices', [&$this, 'adminNoticesMS']);
+		add_action('admin_notices', array(&$this, 'adminNoticesMS'));
+		add_action('network_admin_notices', array(&$this, 'adminNoticesMS'));
 	}
 
 

--- a/core/filters.php
+++ b/core/filters.php
@@ -104,7 +104,7 @@ final class FHTTPS_Core_Filters {
 	public function contentURL($matches) {
 		$tag = (3 == count($matches))?  $matches[1] : null;
 		$protocol = isset($matches[2])? $matches[2] : $matches[1];
-		return (!isset($tag) || in_array($tag, ['img', 'url']) || $this->isInternalLink($matches[0]))? 'https://'.substr($matches[0], strlen($protocol)) : $matches[0];
+		return (!isset($tag) || in_array($tag, array('img', 'url')) || $this->isInternalLink($matches[0]))? 'https://'.substr($matches[0], strlen($protocol)) : $matches[0];
 	}
 
 


### PR DESCRIPTION
Thanks for your work on this plugin!

With the most recent update, the short syntax for PHP arrays breaks PHP 5 installs. These changes fix it again.

Dropping support for PHP 5 at this stage is pretty reasonable, but I'd suggest bumping the major version if the plan is to no longer support it, as it's a breaking change for sites still running on PHP 5.